### PR TITLE
fix race condition with initialization

### DIFF
--- a/pibot_controls/PiBot.py
+++ b/pibot_controls/PiBot.py
@@ -105,6 +105,7 @@ class PiBot:
         rospy.Subscriber("robot/imu/angle", Float32, self.make_callback_for_sensor("rotation_angle"))
 
     def __init__(self, robot_nr=1):
+        self.rotation_angle = "temp"
         # Init node
         rospy.init_node("pibot", anonymous=True)
 
@@ -156,7 +157,8 @@ class PiBot:
         self.CAMERA_FIELD_OF_VIEW = (62.2, 48.8)  # Horizontal,vertical
 
         # Wait for initialisation to finish
-        rospy.sleep(2)
+        while self.rotation_angle == "temp":
+            rospy.sleep(0.1)
 
         # Rotation
         self.starting_rotation = self.rotation_angle


### PR DESCRIPTION
Kui panna "test_robot [uniid] [ÜL] [map] **-w=0**"   siis rospy ei jõua enda rotation_angle muutujat 2 sekundiga pybotile külge panna. Nüüd pybot ootab, kuni self.rotation_angle on initsialiseeritud ja seejärel jätkab.